### PR TITLE
Fix thrush include issue

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/functional.h>
+#include <thrust/count.h>
+#include <thrust/remove.h>
 
 #define NUM_BLOCKS(n, block_size) (((n) + (block_size) - 1) / (block_size))
 #define THREAD_PER_BLOCK 128

--- a/src/misc/print.cu
+++ b/src/misc/print.cu
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "print.cuh"
 
 __global__ void printAIGA(const int * pFanin0, const int * pFanin1, 


### PR DESCRIPTION
There are some errors during compilation. Adding some simple header files will easily resolve this problem.

```
/content/CULS/src/misc/print.cu(9): error: identifier "printf" is undefined
      printf("id\tfanin0\tfanin1\n");
      ^

/content/CULS/src/misc/print.cu(29): error: identifier "printf" is undefined
      printf("-------AIG-------\n");
      ^

/content/CULS/src/misc/print.cu(70): error: identifier "printf" is undefined
      printf("Too small cone: %d, too large cut: %d\n", smallConeCount, largeCount);
      ^

3 errors detected in the compilation of "/content/CULS/src/misc/print.cu".
```

```
/content/CULS/src/aig/strash.cu(235): error: namespace "thrust" has no member "remove_if"
          pNewGlobalListEnd = thrust::remove_if(
                                      ^

/content/CULS/src/algorithms/balance.cu(980): error: namespace "thrust" has no member "remove_if"
          int * pFilteredEnd = thrust::remove_if(
                                       ^

/content/CULS/src/aig/strash.cu(258): error: namespace "thrust" has no member "remove_if"
          pNewGlobalListEnd = thrust::remove_if(
                                      ^

/content/CULS/src/algorithms/balance.cu(1106): error: namespace "thrust" has no member "remove_if"
      int * pNewLastAppearLevelNodesEnd = thrust::remove_if(
                                                  ^

/content/CULS/src/algorithms/balance.cu(1109): error: namespace "thrust" has no member "remove"
      int * pNewLastAppearLevelEnd = thrust::remove(thrust::device, vLastAppearLevel, vLastAppearLevel + nObjs, -1);
                                             ^

/content/CULS/src/algorithms/balance.cu(1436): error: namespace "thrust" has no member "count"
      pi = thrust::count(thrust::device, vNodesFilter, vNodesFilter + len, 0);
                   ^

/content/CULS/src/algorithms/balance.cu(1437): error: namespace "thrust" has no member "count"
      redundant = thrust::count(thrust::device, vNodesFilter, vNodesFilter + len, -1);
                          ^

/content/CULS/src/algorithms/balance.cu(1438): error: namespace "thrust" has no member "count"
      unique = thrust::count(thrust::device, vNodesFilter, vNodesFilter + len, 1);
                       ^

2 errors detected in the compilation of "/content/CULS/src/aig/strash.cu".
6 errors detected in the compilation of "/content/CULS/src/algorithms/balance.cu".
make[2]: *** [CMakeFiles/gpuls.dir/build.make:168: CMakeFiles/gpuls.dir/src/algorithms/balance.cu.o] Error 2
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/gpuls.dir/build.make:108: CMakeFiles/gpuls.dir/src/aig/strash.cu.o] Error 2
/content/CULS/src/algorithms/resub.cu(827): error: namespace "thrust" has no member "count"
      nDeleted = thrust::count(thrust::device, vMaskValid, vMaskValid+nObjs, STATUS_DELETE);
                         ^

/content/CULS/src/algorithms/resub.cu(835): error: namespace "thrust" has no member "count"
          nValidNew = thrust::count(thrust::device, fanoutRef, fanoutRef+nObjs, iterRound);
                              ^

/content/CULS/src/algorithms/resub.cu(840): error: namespace "thrust" has no member "count"
      nDeletedNew = thrust::count(thrust::device, vMaskValid, vMaskValid+nObjs, STATUS_DELETE);
                            ^

3 errors detected in the compilation of "/content/CULS/src/algorithms/resub.cu".
make[2]: *** [CMakeFiles/gpuls.dir/build.make:228: CMakeFiles/gpuls.dir/src/algorithms/resub.cu.o] Error 2
```